### PR TITLE
fix: test if ~/.ssh folder exist before ssh install

### DIFF
--- a/ssh/install.fish
+++ b/ssh/install.fish
@@ -1,6 +1,16 @@
 #!/usr/bin/env fish
-test -L ~/.ssh/config || {
-	mv ~/.ssh/config ~/.ssh/config.local
-	ln -s $DOTFILES/ssh/config ~/.ssh/config
-}
-test -f ~/.ssh/config.local || touch ~/.ssh/config.local
+
+function ssh_config -d "links ~/.ssh config file and keep a backup"
+	echo $argv | read -l p
+	if not test -e ~/.ssh
+		mkdir ~/.ssh
+		success "A new ~/.ssh folder has been created"
+	end
+	test -L ~/.ssh/config || {
+		mv ~/.ssh/config ~/.ssh/config.local
+		ln -s $DOTFILES/ssh/config ~/.ssh/config
+	}
+	test -f ~/.ssh/config.local || touch ~/.ssh/config.local
+end
+
+ssh_config  ~/.ssh/config.local


### PR DESCRIPTION
Olá Carlos,

Muito muito legal esse seu repositório. Eu estou trocando do zsh para o fish e o encontrei pelo antibody. Parabéns mesmo! 
Quero mandar um sponsor assim que possível.

Como eu estava aproveitando uma mudança do Mojave para o Catalina também aproveitei para sair do zsh para o fish. Percebi que em uma instalação "zerada", durante o processo de instalação um erro aconteçe no passo referente a configuração do ssh:

![Screen Shot 2020-09-02 at 21 05 28](https://user-images.githubusercontent.com/247386/92060934-71844980-ed6b-11ea-8317-8f1c4f7678bf.png)

Por isso pensei em fazer esse PR. Como eu nunca havia trabalhado com o fish posso não ter feito um bom código, de qualquer forma segue para sua avaliação.
