### PR TITLE
Test if $HOME/.config/htop folder exist before link htoprc file

### DIFF
--- a/script/bootstrap.fish
+++ b/script/bootstrap.fish
@@ -99,7 +99,9 @@ function install_dotfiles
 			or abort 'failed to link config file'
 	end
 
-	link_file htop/htoprc $HOME/.config/htop/htoprc
+	if test -e $HOME/.config/htop
+		link_file htop/htoprc $HOME/.config/htop/htoprc
+	end
 end
 
 if test -z $OMF_CONFIG || test -z $OMF_PATH


### PR DESCRIPTION
Nesse caso eu não conhecia e não usava o **htop** (a partir de agora vou).

De qualquer forma adicionar um ```test -e``` para não travar instalações que possam vir de um Brewfile difrente.

![Untitled](https://user-images.githubusercontent.com/247386/92063662-130e9980-ed72-11ea-9a25-12a39961ecb2.png)
