### PR TITLE
fix: enable git-main-branch to figure out branch from subdirs

### DIFF
--- a/bin/git-main-branch
+++ b/bin/git-main-branch
@@ -1,5 +1,6 @@
 #!/usr/bin/env fish
-if test -f .git/refs/remotes/origin/main
+set toplevel (git rev-parse --show-toplevel)
+and if test -f $toplevel/.git/refs/remotes/origin/main
 	echo main
 else
 	echo master


### PR DESCRIPTION
Got confused to why my branch switching alias didn't work sometimes in our monorepo 😄 